### PR TITLE
Kratos should return 500s on exceptions

### DIFF
--- a/session/handler.go
+++ b/session/handler.go
@@ -215,13 +215,20 @@ func (h *Handler) whoami(w http.ResponseWriter, r *http.Request, _ httprouter.Pa
 	s, err := h.r.SessionManager().FetchFromRequest(ctx, r)
 	c := h.r.Config()
 	if err != nil {
+		h.r.Audit().WithRequest(r).WithError(err).Info("No valid session found.")
+
 		// We cache errors (and set cache header only when configured) where no session was found.
-		if noSess := new(ErrNoActiveSessionFound); c.SessionWhoAmICaching(ctx) && errors.As(err, &noSess) && noSess.credentialsMissing {
-			w.Header().Set("Ory-Session-Cache-For", fmt.Sprintf("%d", int64(time.Minute.Seconds())))
+		if noSess := new(ErrNoActiveSessionFound); errors.As(err, &noSess) {
+			if c.SessionWhoAmICaching(ctx) && noSess.credentialsMissing {
+				w.Header().Set("Ory-Session-Cache-For", fmt.Sprintf("%d", int64(time.Minute.Seconds())))
+			}
+
+			h.r.Writer().WriteError(w, r, ErrNoSessionFound.WithWrap(err))
+			return
+
 		}
 
-		h.r.Audit().WithRequest(r).WithError(err).Info("No valid session found.")
-		h.r.Writer().WriteError(w, r, ErrNoSessionFound.WithWrap(err))
+		h.r.Writer().WriteError(w, r, herodot.ErrInternalServerError.WithReasonf("Unable to validate session.").WithWrap(err))
 		return
 	}
 


### PR DESCRIPTION
https://fulcrumapp.atlassian.net/browse/FLCRM-15120

Using the fulcrum-kratos project, edit the values file. Remove any of these DSN parameters:
* max_conn_idle_time
* prefer_simple_protocol
* statement_cache_capacity

Update the image tag to be `bbba4469d06b837cdfe5cea28e2f4c68a4b5674a`.

Then run through the Kratos login flow. Test these scenarios:

* Call `{{host}}/api/_private/session/sessions/whoami` with a valid session token. You should get either a 200 on the first try and a 500 several attempts later.
* Call `{{host}}/api/_private/session/sessions/whoami` with an invalid session token. You should get either a 401 on the first try.

We are testing a bad database connection, so we are expecting errors. You may have to restart your pods several times. This is the easiest command:
```
skaffold run
```

If that does not work:
```
skaffold delete && skaffold run
```